### PR TITLE
Fix/diffable data source collison#36

### DIFF
--- a/Tekken8 Frame Data/TK8/Repository/Data/DTO/CharacterDTO.swift
+++ b/Tekken8 Frame Data/TK8/Repository/Data/DTO/CharacterDTO.swift
@@ -31,6 +31,12 @@ struct CharacterDTO {
         Character(id: id, nameEN: nameEN, nameKR: nameKR, imageURL: imageURL)
     }
     
+    func update(_ entity: CharacterEntity) {
+        entity.nameEN = nameEN
+        entity.nameKR = nameKR
+        entity.imageURL = imageURL
+    }
+    
     @discardableResult
     func toEntity(in context: NSManagedObjectContext) -> CharacterEntity {
         let entity = CharacterEntity(context: context)

--- a/Tekken8 Frame Data/TK8/Repository/Data/DTO/MoveDTO.swift
+++ b/Tekken8 Frame Data/TK8/Repository/Data/DTO/MoveDTO.swift
@@ -81,6 +81,23 @@ struct MoveDTO {
         )
     }
     
+    func update(_ entity: MoveEntity) {
+        entity.characterName = characterName
+        entity.section = section
+        entity.skillNameEN = skillNameEN
+        entity.skillNameKR = skillNameKR
+        entity.skillNickname = skillNickname
+        entity.command = command
+        entity.judgment = judgment
+        entity.damage = damage
+        entity.startupFrame = startupFrame
+        entity.guardFrame = guardFrame
+        entity.hitFrame = hitFrame
+        entity.counterFrame = counterFrame
+        entity.attribute = attribute
+        entity.descriptions = description
+    }
+    
     @discardableResult
     func toEntity(context: NSManagedObjectContext) -> MoveEntity {
         let entity = MoveEntity(context: context)


### PR DESCRIPTION
<!--
PR 이름 컨벤션
~~(#issueNum)
-->

##  📌 관련 이슈

- closed #36 

## ✨ 세부 내용

이전 버전에서 해결한 줄 알았던 diffableDataSource 충돌이 현 버전에도 발생하여 Core Data에 저장하는 로직을 수정하였습니다.

## ✍️ 고민한 내용

기존에는 addToCoreData 메서드를 호출하면 무조건 저장되게 하였지만, 데이터를 패치한 후 바로 저장하지 않고, coreData에 저장된 동일한 id 를 가진 원소가 존재할 경우, 값을 업데이트 하는 방식으로 수정하고, 값이 없다면 add 해주는 로직으로 수정하였습니다.

## ⌛ 소요 시간
30m