### PR TITLE
fix: 메모 작성 화면 키보드 UX 개선

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,11 +14,11 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - name: 🔎 Check Available Xcode Version 🔎
-      run: ls /Applications | grep Xcode
-
-    - name: Select Xcode Version 16.4
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+    - name: 🔎 Check Default Xcode Version 🔎
+      run: |
+        xcodebuild -version
+        xcode-select -p
+        ls /Applications | grep Xcode
     
     - name: Get Path
       run: pwd

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -33,4 +33,4 @@ jobs:
       run: xcodebuild -resolvePackageDependencies -project "Tekken8 Frame Data/TK8.xcodeproj"
 
     - name: 🛠️ Build Project 🛠️
-      run: xcodebuild clean build -project "Tekken8 Frame Data/TK8.xcodeproj" -scheme "Tekken8 Frame Data" -destination "platform=iOS Simulator,name=iPhone 16,OS=latest"
+      run: xcodebuild clean build -project "Tekken8 Frame Data/TK8.xcodeproj" -scheme "Tekken8 Frame Data" -destination "generic/platform=iOS Simulator"

--- a/Tekken8 Frame Data/TK8/Memo/Controller/MemoComposeViewController.swift
+++ b/Tekken8 Frame Data/TK8/Memo/Controller/MemoComposeViewController.swift
@@ -14,6 +14,7 @@ final class MemoComposeViewController: BaseViewController {
     private var memo: Memo?
     private var selectedCharacterName: String?
     private var isPinned: Bool
+    private var isTextEditing = false
 
     init(
         memoViewModel: MemoViewModel,
@@ -60,7 +61,7 @@ final class MemoComposeViewController: BaseViewController {
 
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        composeRightBarButton()
+        composeRightBarButtons()
     }
 
     override func setupDelegation() {
@@ -72,6 +73,10 @@ final class MemoComposeViewController: BaseViewController {
         let characterSelectViewController = makeCharacterSelectViewController()
         characterSelectViewController.delegate = self
         navigationController?.pushViewController(characterSelectViewController, animated: true)
+    }
+
+    @objc private func doneButtonTapped() {
+        view.endEditing(true)
     }
 
     private func save() {
@@ -106,11 +111,24 @@ final class MemoComposeViewController: BaseViewController {
         return memo?.characterName != selectedCharacterName || memo?.title != title || memo?.body != body || memo?.isPinned != isPinned
     }
 
-    private func composeRightBarButton() {
-        if !memoComposeView.bodyContent.isEmpty || !memoComposeView.titleContent.isEmpty {
-            navigationItem.rightBarButtonItem = generateEllipsisButton()
+    private func composeRightBarButtons() {
+        let hasContent = !memoComposeView.bodyContent.isEmpty || !memoComposeView.titleContent.isEmpty
+        let ellipsisButton = hasContent ? generateEllipsisButton() : nil
+
+        guard isTextEditing else {
+            navigationItem.rightBarButtonItems = ellipsisButton.map { [$0] }
+            return
+        }
+
+        let doneButton = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(doneButtonTapped)
+        )
+        if let ellipsisButton {
+            navigationItem.rightBarButtonItems = [doneButton, ellipsisButton]
         } else {
-            navigationItem.rightBarButtonItem = .none
+            navigationItem.rightBarButtonItems = [doneButton]
         }
     }
 
@@ -127,7 +145,7 @@ final class MemoComposeViewController: BaseViewController {
             }
         } togglePin: {
             self.isPinned.toggle()
-            self.composeRightBarButton()
+            self.composeRightBarButtons()
         }
         let ellipsisButton = UIBarButtonItem(
             image: UIImage(systemName: "ellipsis"),
@@ -152,9 +170,20 @@ extension MemoComposeViewController: Selectable {
 }
 
 extension MemoComposeViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        isTextEditing = true
+        composeRightBarButtons()
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        isTextEditing = false
+        composeRightBarButtons()
+    }
+
     func textViewDidChange(_ textView: UITextView) {
         memoComposeView.updatePlaceholders()
-        composeRightBarButton()
+        memoComposeView.scrollCaretToVisible(in: textView)
+        composeRightBarButtons()
     }
 
     func textView(_ textView: UITextView, shouldChangeTextInRanges ranges: [NSValue], replacementText text: String) -> Bool {

--- a/Tekken8 Frame Data/TK8/Memo/Controller/MemoComposeViewController.swift
+++ b/Tekken8 Frame Data/TK8/Memo/Controller/MemoComposeViewController.swift
@@ -15,6 +15,12 @@ final class MemoComposeViewController: BaseViewController {
     private var selectedCharacterName: String?
     private var isPinned: Bool
     private var isTextEditing = false
+    private var ellipsisButton: UIBarButtonItem?
+    private var ellipsisButtonState: EllipsisButtonState?
+
+    private struct EllipsisButtonState: Equatable {
+        let isPinned: Bool
+    }
 
     init(
         memoViewModel: MemoViewModel,
@@ -113,7 +119,7 @@ final class MemoComposeViewController: BaseViewController {
 
     private func composeRightBarButtons() {
         let hasContent = !memoComposeView.bodyContent.isEmpty || !memoComposeView.titleContent.isEmpty
-        let ellipsisButton = hasContent ? generateEllipsisButton() : nil
+        let ellipsisButton = currentEllipsisButton(hasContent: hasContent)
 
         guard isTextEditing else {
             navigationItem.rightBarButtonItems = ellipsisButton.map { [$0] }
@@ -132,8 +138,24 @@ final class MemoComposeViewController: BaseViewController {
         }
     }
 
+    private func currentEllipsisButton(hasContent: Bool) -> UIBarButtonItem? {
+        guard hasContent else {
+            ellipsisButton = nil
+            ellipsisButtonState = nil
+            return nil
+        }
+
+        let state = EllipsisButtonState(isPinned: isPinned)
+        if ellipsisButtonState != state {
+            ellipsisButton = generateEllipsisButton()
+            ellipsisButtonState = state
+        }
+        return ellipsisButton
+    }
+
     private func generateEllipsisButton() -> UIBarButtonItem {
-        let menu = MemoMenuFactory.menu(isPinned: self.isPinned) {
+        let menu = MemoMenuFactory.menu(isPinned: isPinned) { [weak self] in
+            guard let self else { return }
             // Delete
             do {
                 if let memo = self.memo {
@@ -143,7 +165,8 @@ final class MemoComposeViewController: BaseViewController {
             } catch {
 
             }
-        } togglePin: {
+        } togglePin: { [weak self] in
+            guard let self else { return }
             self.isPinned.toggle()
             self.composeRightBarButtons()
         }

--- a/Tekken8 Frame Data/TK8/Memo/Controller/MemoComposeViewController.swift
+++ b/Tekken8 Frame Data/TK8/Memo/Controller/MemoComposeViewController.swift
@@ -186,6 +186,10 @@ extension MemoComposeViewController: UITextViewDelegate {
         composeRightBarButtons()
     }
 
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        memoComposeView.scrollCaretToVisible(in: textView)
+    }
+
     func textView(_ textView: UITextView, shouldChangeTextInRanges ranges: [NSValue], replacementText text: String) -> Bool {
         // Title에서 Enter 입력 시 body로 이동
         if textView === memoComposeView.titleField, text == "\n" {

--- a/Tekken8 Frame Data/TK8/Memo/View/MemoComposeView.swift
+++ b/Tekken8 Frame Data/TK8/Memo/View/MemoComposeView.swift
@@ -68,6 +68,8 @@ final class MemoComposeView: BaseView {
         textView.font = .systemFont(ofSize: 16)
         textView.textColor = .white
         textView.backgroundColor = .clear
+        textView.alwaysBounceVertical = true
+        textView.keyboardDismissMode = .interactive
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         return textView
@@ -131,6 +133,13 @@ final class MemoComposeView: BaseView {
 
     func activateTextView() {
         bodyTextView.becomeFirstResponder()
+    }
+
+    func scrollCaretToVisible(in textView: UITextView) {
+        guard let selectedRange = textView.selectedTextRange else { return }
+
+        let caretRect = textView.caretRect(for: selectedRange.end)
+        textView.scrollRectToVisible(caretRect.insetBy(dx: 0, dy: -12), animated: true)
     }
 
     // MARK: - Private
@@ -209,7 +218,7 @@ private extension MemoComposeView {
             bodyTextView.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 12),
             bodyTextView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
             bodyTextView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            bodyTextView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bodyTextView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor, constant: -12),
 
             bodyPlaceholder.topAnchor.constraint(equalTo: bodyTextView.topAnchor),
             bodyPlaceholder.leadingAnchor.constraint(equalTo: bodyTextView.leadingAnchor),


### PR DESCRIPTION
## Summary
- 메모 작성 화면의 본문 입력 영역을 키보드 높이에 맞춰 조정했습니다.
- 긴 메모 작성 중 caret이 보이도록 스크롤 보정을 추가했습니다.
- 편집 중일 때만 navigation bar에 Done 버튼을 표시해 키보드를 내릴 수 있게 했습니다.

## Why
메모가 길어질 때 입력 위치가 키보드 아래로 가려지고, 키보드를 명시적으로 내릴 수 없는 문제가 있었습니다.

## Validation
- git diff --check
- xcodebuild test -project 'Tekken8 Frame Data/TK8.xcodeproj' -scheme 'TK8Tests' -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -derivedDataPath /private/tmp/TK8DerivedData-issue61

Fixes #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메모 작성/편집 화면에서 텍스트 입력 상태에 따라 우측 상단 버튼 구성이 동적으로 갱신됩니다(편집 중 완료 버튼 표시 포함).
  * 핀 상태 전환 후에도 우측 버튼이 즉시 반영됩니다.
* **버그 수정**
  * 키보드 표시 중에도 커서 위치가 화면에 잘 보이도록 스크롤 동작을 개선했습니다.
  * 텍스트 뷰의 키보드 연동(바운스/키보드 해제 동작)과 하단 표시 영역을 조정해 작성이 더 안정적으로 보이게 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->