### PR TITLE
feat: 메모 내보내기/불러오기 추가

### DIFF
--- a/Tekken8 Frame Data/TK8.xcodeproj/project.pbxproj
+++ b/Tekken8 Frame Data/TK8.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2.0.3;
+				CURRENT_PROJECT_VERSION = 2.0.4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = K4356CVQKW;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -351,7 +351,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.3;
+				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.moongoon.TK8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -377,7 +377,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2.0.3;
+				CURRENT_PROJECT_VERSION = 2.0.4;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = K4356CVQKW;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.3;
+				MARKETING_VERSION = 2.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.moongoon.TK8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Tekken8 Frame Data/TK8/Info.plist
+++ b/Tekken8 Frame Data/TK8/Info.plist
@@ -4,6 +4,21 @@
 <dict>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>TK8 Memo Backup</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.moongoon.tk8.memos</string>
+			</array>
+		</dict>
+	</array>
 	<key>SUPABASE_URL</key>
 	<string>$(SUPABASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>
@@ -23,6 +38,28 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>TK8 Memo Backup</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.moongoon.tk8.memos</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>tk8memos</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/json</string>
+			</dict>
+		</dict>
+	</array>
 	<key>Version</key>
 	<string>1</string>
 </dict>

--- a/Tekken8 Frame Data/TK8/Localizable.xcstrings
+++ b/Tekken8 Frame Data/TK8/Localizable.xcstrings
@@ -971,6 +971,193 @@
         }
       }
     },
+    "Cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        }
+      }
+    },
+    "Export All Memos": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export All Memos"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 메모 내보내기"
+          }
+        }
+      }
+    },
+    "Export Failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내보내기 실패"
+          }
+        }
+      }
+    },
+    "Import": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "불러오기"
+          }
+        }
+      }
+    },
+    "Import Complete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Complete"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "불러오기 완료"
+          }
+        }
+      }
+    },
+    "Import Failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Failed"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "불러오기 실패"
+          }
+        }
+      }
+    },
+    "Import Memos": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Memos"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모 불러오기"
+          }
+        }
+      }
+    },
+    "Imported %d new memos, updated %d memos, and skipped %d memos.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported %d new memos, updated %d memos, and skipped %d memos."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 메모 %d개를 추가하고, %d개를 업데이트했으며, %d개는 유지했습니다."
+          }
+        }
+      }
+    },
+    "Memos from the selected file will be merged with your current memos. Newer memos with the same ID will replace older ones.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memos from the selected file will be merged with your current memos. Newer memos with the same ID will replace older ones."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 파일의 메모를 현재 메모와 병합합니다. 같은 ID의 메모는 더 최신 메모가 이전 메모를 대체합니다."
+          }
+        }
+      }
+    },
+    "Unable to export memos.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to export memos."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모를 내보낼 수 없습니다."
+          }
+        }
+      }
+    },
+    "Unable to import memos.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to import memos."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메모를 불러올 수 없습니다."
+          }
+        }
+      }
+    },
     "Donation": {
       "extractionState": "manual",
       "localizations": {

--- a/Tekken8 Frame Data/TK8/Memo/Controller/MemoListViewController.swift
+++ b/Tekken8 Frame Data/TK8/Memo/Controller/MemoListViewController.swift
@@ -197,6 +197,9 @@ final class MemoListViewController: BaseViewController {
 
     private func presentShareSheet(fileURL: URL) {
         let activityViewController = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
+        activityViewController.completionWithItemsHandler = { _, _, _, _ in
+            try? FileManager.default.removeItem(at: fileURL)
+        }
         if let popover = activityViewController.popoverPresentationController {
             popover.sourceView = view
             popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)

--- a/Tekken8 Frame Data/TK8/Memo/Controller/MemoListViewController.swift
+++ b/Tekken8 Frame Data/TK8/Memo/Controller/MemoListViewController.swift
@@ -5,6 +5,7 @@
 
 import Combine
 import UIKit
+import UniformTypeIdentifiers
 
 final class MemoListViewController: BaseViewController {
     private typealias Snapshot = NSDiffableDataSourceSnapshot<MemoSection, Memo>
@@ -16,6 +17,7 @@ final class MemoListViewController: BaseViewController {
     private let memoViewModel: MemoViewModel
     private var dataSource: memoDataSource?
     private let characterListViewModel: any CharacterSelectable
+    private var importConfirmationURL: URL?
 
     private let makeMemoComposeViewController: MemoComposeFactory
 
@@ -111,6 +113,26 @@ final class MemoListViewController: BaseViewController {
         }
     }
 
+    private func exportAllMemos() {
+        do {
+            let export = try memoViewModel.exportMemos()
+            let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(export.fileName)
+            try export.data.write(to: fileURL, options: .atomic)
+            presentShareSheet(fileURL: fileURL)
+        } catch {
+            presentAlert(title: "Export Failed".localized(), message: "Unable to export memos.".localized())
+        }
+    }
+
+    private func importMemos() {
+        let picker = UIDocumentPickerViewController(
+            forOpeningContentTypes: [MemoBackupDocument.contentType],
+            asCopy: true
+        )
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
     func toggleEditingMode() {
         isEditing.toggle()
         memoListView.collectionView.allowsMultipleSelection = isEditing
@@ -122,6 +144,12 @@ final class MemoListViewController: BaseViewController {
 
     private func composeRightBarButtons() {
         let menuItems: [UIAction] = {
+            let exportAllMemos = UIAction(title: "Export All Memos".localized(), image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+                self?.exportAllMemos()
+            }
+            let importMemos = UIAction(title: "Import Memos".localized(), image: UIImage(systemName: "square.and.arrow.down")) { [weak self] _ in
+                self?.importMemos()
+            }
             let multiSelect = UIAction(title: "Select memo".localized(), image: UIImage(systemName: "checkmark.circle")) { [weak self] _ in
                 self?.navigationController?.isToolbarHidden = false
                 self?.toggleEditingMode()
@@ -141,7 +169,7 @@ final class MemoListViewController: BaseViewController {
                     )
                 ]
             }
-            let items = [multiSelect]
+            let items = [exportAllMemos, importMemos, multiSelect]
             return items
         }()
         let composeButton = UIBarButtonItem(
@@ -165,6 +193,63 @@ final class MemoListViewController: BaseViewController {
         } else {
             navigationItem.rightBarButtonItems = [ellipsisButton, composeButton]
         }
+    }
+
+    private func presentShareSheet(fileURL: URL) {
+        let activityViewController = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
+        if let popover = activityViewController.popoverPresentationController {
+            popover.sourceView = view
+            popover.sourceRect = CGRect(x: view.bounds.midX, y: view.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+        present(activityViewController, animated: true)
+    }
+
+    private func presentImportConfirmation(fileURL: URL) {
+        importConfirmationURL = fileURL
+        let alert = UIAlertController(
+            title: "Import Memos".localized(),
+            message: "Memos from the selected file will be merged with your current memos. Newer memos with the same ID will replace older ones.".localized(),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel".localized(), style: .cancel) { [weak self] _ in
+            self?.importConfirmationURL = nil
+        })
+        alert.addAction(UIAlertAction(title: "Import".localized(), style: .default) { [weak self] _ in
+            guard let self, let url = self.importConfirmationURL else { return }
+            self.importConfirmationURL = nil
+            self.importMemos(from: url)
+        })
+        present(alert, animated: true)
+    }
+
+    private func importMemos(from fileURL: URL) {
+        let shouldStopAccessing = fileURL.startAccessingSecurityScopedResource()
+        defer {
+            if shouldStopAccessing {
+                fileURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let result = try memoViewModel.importMemos(from: data)
+            let message = String(
+                format: "Imported %d new memos, updated %d memos, and skipped %d memos.".localized(),
+                result.insertedCount,
+                result.updatedCount,
+                result.skippedCount
+            )
+            presentAlert(title: "Import Complete".localized(), message: message)
+        } catch {
+            presentAlert(title: "Import Failed".localized(), message: "Unable to import memos.".localized())
+        }
+    }
+
+    private func presentAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Accept".localized(), style: .default))
+        present(alert, animated: true)
     }
 }
 
@@ -284,6 +369,13 @@ extension MemoListViewController: UICollectionViewDelegate {
             }
         }
         return config
+    }
+}
+
+extension MemoListViewController: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let fileURL = urls.first else { return }
+        presentImportConfirmation(fileURL: fileURL)
     }
 }
 

--- a/Tekken8 Frame Data/TK8/Memo/Model/MemoBackup.swift
+++ b/Tekken8 Frame Data/TK8/Memo/Model/MemoBackup.swift
@@ -1,0 +1,155 @@
+//
+//  MemoBackup.swift
+//  TK8
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+struct MemoBackupExport {
+    let data: Data
+    let fileName: String
+}
+
+struct MemoImportResult: Equatable {
+    let insertedCount: Int
+    let updatedCount: Int
+    let skippedCount: Int
+}
+
+struct MemoBackupFile: Codable, Equatable {
+    let formatVersion: Int
+    let exportedAt: Date
+    let memos: [MemoBackupItem]
+
+    init(formatVersion: Int = 1, exportedAt: Date = Date(), memos: [Memo]) {
+        self.formatVersion = formatVersion
+        self.exportedAt = exportedAt
+        self.memos = memos.map(MemoBackupItem.init)
+    }
+}
+
+struct MemoBackupItem: Codable, Equatable {
+    let id: UUID
+    let characterName: String
+    let title: String
+    let body: String
+    let isPinned: Bool
+    let updatedAt: Date
+
+    init(memo: Memo) {
+        id = memo.id
+        characterName = memo.characterName
+        title = memo.title
+        body = memo.body
+        isPinned = memo.isPinned
+        updatedAt = memo.updatedAt
+    }
+
+    var memo: Memo {
+        Memo(
+            id: id,
+            characterName: characterName,
+            title: title,
+            body: body,
+            isPinned: isPinned,
+            updatedAt: updatedAt
+        )
+    }
+}
+
+struct MemoBackupCodec {
+    func encode(memos: [Memo], exportedAt: Date = Date()) throws -> Data {
+        let backup = MemoBackupFile(exportedAt: exportedAt, memos: memos)
+        return try JSONEncoder.memoBackup.encode(backup)
+    }
+
+    func decodeMemos(from data: Data) throws -> [Memo] {
+        let backup = try JSONDecoder.memoBackup.decode(MemoBackupFile.self, from: data)
+        guard backup.formatVersion == 1 else {
+            throw MemoBackupError.unsupportedFormatVersion(backup.formatVersion)
+        }
+        return backup.memos.map(\.memo)
+    }
+}
+
+enum MemoBackupError: Error {
+    case unsupportedFormatVersion(Int)
+}
+
+enum MemoBackupDocument {
+    static let fileExtension = "tk8memos"
+    static let contentType = UTType(exportedAs: "com.moongoon.tk8.memos", conformingTo: .json)
+
+    static func fileName(exportedAt: Date = Date()) -> String {
+        let date = MemoBackupFileNameFormatter.string(from: exportedAt)
+        return "tekken8-memos-\(date).\(fileExtension)"
+    }
+}
+
+private enum MemoBackupFileNameFormatter {
+    static func string(from date: Date) -> String {
+        formatter.string(from: date)
+    }
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter
+    }()
+}
+
+private extension JSONEncoder {
+    static var memoBackup: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(MemoBackupDateFormatter.string(from: date))
+        }
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var memoBackup: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            guard let date = MemoBackupDateFormatter.date(from: string) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid date format: \(string)"
+                )
+            }
+            return date
+        }
+        return decoder
+    }
+}
+
+private enum MemoBackupDateFormatter {
+    static func string(from date: Date) -> String {
+        fractionalFormatter.string(from: date)
+    }
+
+    static func date(from string: String) -> Date? {
+        fractionalFormatter.date(from: string) ?? standardFormatter.date(from: string)
+    }
+
+    private static let fractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let standardFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/Tekken8 Frame Data/TK8/Memo/ViewModel/MemoViewModel.swift
+++ b/Tekken8 Frame Data/TK8/Memo/ViewModel/MemoViewModel.swift
@@ -10,9 +10,11 @@ final class MemoViewModel: ObservableObject {
     @Published private(set) var filteredMemos: [Memo] = []
     private(set) var memos: [Memo] = []
     private let memoRepository: MemoRepository
+    private let memoBackupCodec: MemoBackupCodec
 
-    init(memoRepository: MemoRepository) {
+    init(memoRepository: MemoRepository, memoBackupCodec: MemoBackupCodec = MemoBackupCodec()) {
         self.memoRepository = memoRepository
+        self.memoBackupCodec = memoBackupCodec
     }
 
     // MARK: CRUD methods
@@ -38,6 +40,23 @@ final class MemoViewModel: ObservableObject {
         try performAndFetch {
             try memos.forEach { try memoRepository.delete(memo: $0) }
         }
+    }
+
+    func exportMemos() throws -> MemoBackupExport {
+        let exportedAt = Date()
+        let memos = try memoRepository.fetchMemos()
+        let data = try memoBackupCodec.encode(memos: memos, exportedAt: exportedAt)
+        return MemoBackupExport(
+            data: data,
+            fileName: MemoBackupDocument.fileName(exportedAt: exportedAt)
+        )
+    }
+
+    func importMemos(from data: Data) throws -> MemoImportResult {
+        let memos = try memoBackupCodec.decodeMemos(from: data)
+        let result = try memoRepository.upsert(memos: memos)
+        try fetch()
+        return result
     }
 
     // MARK: Filter method

--- a/Tekken8 Frame Data/TK8/Move/Translator/TranslatorEngine.swift
+++ b/Tekken8 Frame Data/TK8/Move/Translator/TranslatorEngine.swift
@@ -23,7 +23,7 @@ final class TranslatorEngine {
                 skillNameSecondary: move.skillNameEN,
                 command: move.command ?? "",
                 commandEN: nil, // ko에선 굳이 안 써도 됨
-                judgment: move.judgment,
+                judgment: JudgmentTranslator.localize(move.judgment, to: .ko),
                 damage: move.damage,
                 startupFrame: move.startupFrame,
                 guardFrame: move.guardFrame,
@@ -56,7 +56,7 @@ final class TranslatorEngine {
             skillNameSecondary: move.skillNameKR,
             command: commandDisplay,          // ⬅️ 동양식 유지
             commandEN: commandEN,        // ⬅️ 검색용 보조
-            judgment: move.judgment,
+            judgment: JudgmentTranslator.localize(move.judgment, to: .en),
             damage: move.damage,
             startupFrame: move.startupFrame,
             guardFrame: move.guardFrame,
@@ -67,5 +67,61 @@ final class TranslatorEngine {
         )
         cache.setObject(Box<LocalizedMove>(value: localized), forKey: key)
         return localized
+    }
+}
+
+enum JudgmentTranslator {
+    private static let tokenMap = [
+        "상": "high",
+        "중": "mid",
+        "하": "low",
+        "특중": "s.mid",
+        "특하": "s.low",
+        "상단가불": "high unblockable",
+        "중단가불": "mid unblockable",
+        "가불": "unblockable",
+    ]
+
+    private static let koreanTokens = tokenMap.keys.sorted { $0.count > $1.count }
+
+    static func localize(_ judgment: String?, to lang: TranslatorEngine.Lang) -> String? {
+        guard let judgment else { return nil }
+        guard lang == .en else { return judgment }
+
+        let tokens = tokenize(judgment)
+        guard !tokens.isEmpty else { return judgment }
+        return tokens.map { tokenMap[$0] ?? $0 }.joined(separator: " ")
+    }
+
+    private static func tokenize(_ judgment: String) -> [String] {
+        let trimmed = judgment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let separators = CharacterSet(charactersIn: ",/|·・ㆍ").union(.whitespacesAndNewlines)
+        let parts = trimmed.components(separatedBy: separators).filter { !$0.isEmpty }
+        if parts.count > 1 {
+            return parts.flatMap(tokenizeSinglePart)
+        }
+
+        return tokenizeSinglePart(trimmed)
+    }
+
+    private static func tokenizeSinglePart(_ part: String) -> [String] {
+        if tokenMap[part] != nil { return [part] }
+
+        var remaining = part
+        var tokens: [String] = []
+
+        while !remaining.isEmpty {
+            guard let token = koreanTokens.first(where: { remaining.hasPrefix($0) }) else {
+                remaining.removeFirst()
+                continue
+            }
+
+            tokens.append(token)
+            remaining.removeFirst(token.count)
+        }
+
+        return tokens
     }
 }

--- a/Tekken8 Frame Data/TK8/Move/View/Cell/MoveCell.swift
+++ b/Tekken8 Frame Data/TK8/Move/View/Cell/MoveCell.swift
@@ -102,10 +102,10 @@ struct JudgeBadge: View {
 
     private var badgeColor: Color {
         switch text {
-        case "상": return Color(red: 0.94, green: 0.37, blue: 0.37)  // coral red
-        case "중": return Color(red: 0.98, green: 0.78, blue: 0.46)  // warm amber
-        case "하": return Color(red: 0.52, green: 0.72, blue: 0.92)  // soft blue
-        case "특중": return Color(red: 0.36, green: 0.79, blue: 0.65) // teal
+        case "상", "high": return Color(red: 0.94, green: 0.37, blue: 0.37)  // coral red
+        case "중", "mid": return Color(red: 0.98, green: 0.78, blue: 0.46)  // warm amber
+        case "하", "low": return Color(red: 0.52, green: 0.72, blue: 0.92)  // soft blue
+        case "특중", "s.mid": return Color(red: 0.36, green: 0.79, blue: 0.65) // teal
         default:   return Color(red: 0.68, green: 0.60, blue: 0.88)  // soft purple
         }
     }
@@ -320,26 +320,29 @@ struct FlowLayout: Layout {
 private extension String {
     /// "중중중", "중,중,상", "상/중|하", "상 중 하" 모두 ["중","중","중"] 등으로 분리
     func tokenizeJudgments() -> [String] {
-            let allowed = Set(["상", "중", "하", "특중", "특하", "상단가불", "중단가불", "가불"]) // ← 특중 추가
-            let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return [] }
+        let allowed = Set([
+            "상", "중", "하", "특중", "특하", "상단가불", "중단가불", "가불",
+            "high", "mid", "low", "s.mid", "s.low", "unblockable",
+        ])
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
 
-            // 1) 구분자 기준 split
-            let separators = CharacterSet(charactersIn: ",/|·・ㆍ").union(.whitespacesAndNewlines)
-            let parts = trimmed.components(separatedBy: separators).filter { !$0.isEmpty }
+        // 1) 구분자 기준 split
+        let separators = CharacterSet(charactersIn: ",/|·・ㆍ").union(.whitespacesAndNewlines)
+        let parts = trimmed.components(separatedBy: separators).filter { !$0.isEmpty }
 
-            if parts.count > 1 {
-                return parts.filter { allowed.contains($0) }
-            }
-
-            // 2) 단일 토큰인 경우: 전체가 allowed면 그대로 반환
-            if allowed.contains(trimmed) {
-                return [trimmed]
-            }
-
-            // 3) 글자 단위 fallback
-            return trimmed.map { String($0) }.filter { allowed.contains($0) }
+        if parts.count > 1 {
+            return parts.filter { allowed.contains($0) }
         }
+
+        // 2) 단일 토큰인 경우: 전체가 allowed면 그대로 반환
+        if allowed.contains(trimmed) {
+            return [trimmed]
+        }
+
+        // 3) 글자 단위 fallback
+        return trimmed.map { String($0) }.filter { allowed.contains($0) }
+    }
 
     /// "상중하" → ["상","중","하"]; "중중중" → ["중","중","중"]
     func expandJudgmentRun() -> [String] {

--- a/Tekken8 Frame Data/TK8/Move/View/Cell/MoveCell.swift
+++ b/Tekken8 Frame Data/TK8/Move/View/Cell/MoveCell.swift
@@ -323,9 +323,14 @@ private extension String {
         let allowed = Set([
             "상", "중", "하", "특중", "특하", "상단가불", "중단가불", "가불",
             "high", "mid", "low", "s.mid", "s.low", "unblockable",
+            "high unblockable", "mid unblockable",
         ])
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
+
+        if allowed.contains(trimmed) {
+            return [trimmed]
+        }
 
         // 1) 구분자 기준 split
         let separators = CharacterSet(charactersIn: ",/|·・ㆍ").union(.whitespacesAndNewlines)
@@ -335,12 +340,7 @@ private extension String {
             return parts.filter { allowed.contains($0) }
         }
 
-        // 2) 단일 토큰인 경우: 전체가 allowed면 그대로 반환
-        if allowed.contains(trimmed) {
-            return [trimmed]
-        }
-
-        // 3) 글자 단위 fallback
+        // 2) 글자 단위 fallback
         return trimmed.map { String($0) }.filter { allowed.contains($0) }
     }
 

--- a/Tekken8 Frame Data/TK8/Repository/Data/DefaultMemoRepository.swift
+++ b/Tekken8 Frame Data/TK8/Repository/Data/DefaultMemoRepository.swift
@@ -11,6 +11,7 @@ protocol MemoRepository {
     func fetchMemos() throws -> [Memo]
     func update(memo: Memo) throws
     func delete(memo: Memo) throws
+    func upsert(memos: [Memo]) throws -> MemoImportResult
 }
 
 final class DefaultMemoRepository: MemoRepository {
@@ -31,6 +32,34 @@ final class DefaultMemoRepository: MemoRepository {
         entity.updatedAt = Date()
         try coreDataManager.saveContext()
     }
+
+    func upsert(memos: [Memo]) throws -> MemoImportResult {
+        var insertedCount = 0
+        var updatedCount = 0
+        var skippedCount = 0
+
+        for memo in memos {
+            if let entity = try fetchMemoEntity(id: memo.id) {
+                guard shouldUpdate(entity: entity, with: memo) else {
+                    skippedCount += 1
+                    continue
+                }
+                apply(memo, to: entity, preserveUpdatedAt: true)
+                updatedCount += 1
+            } else {
+                let entity = MemoEntity(context: coreDataManager.context)
+                apply(memo, to: entity, preserveUpdatedAt: true)
+                insertedCount += 1
+            }
+        }
+
+        try coreDataManager.saveContext()
+        return MemoImportResult(
+            insertedCount: insertedCount,
+            updatedCount: updatedCount,
+            skippedCount: skippedCount
+        )
+    }
     
     func fetchMemos() throws -> [Memo] {
         let request = MemoEntity.fetchRequest()
@@ -49,10 +78,7 @@ final class DefaultMemoRepository: MemoRepository {
     }
     
     func update(memo: Memo) throws {
-        let request = MemoEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "id == %@", memo.id as CVarArg)
-        let prevMemo = try coreDataManager.fetch(request)
-        guard let entity = prevMemo.first else { return }
+        guard let entity = try fetchMemoEntity(id: memo.id) else { return }
 
         // Pin만 바뀐경우 Date를 갱신하면 안됨
         if isPinOnlyChanged(from: entity, to: memo) {
@@ -80,5 +106,26 @@ final class DefaultMemoRepository: MemoRepository {
             entity.title == memo.title &&
             entity.body == memo.body &&
             entity.isPinned != memo.isPinned
+    }
+
+    private func fetchMemoEntity(id: UUID) throws -> MemoEntity? {
+        let request = MemoEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        return try coreDataManager.fetch(request).first
+    }
+
+    private func shouldUpdate(entity: MemoEntity, with memo: Memo) -> Bool {
+        let updatedAt = entity.updatedAt ?? .distantPast
+        return memo.updatedAt > updatedAt
+    }
+
+    private func apply(_ memo: Memo, to entity: MemoEntity, preserveUpdatedAt: Bool) {
+        entity.id = memo.id
+        entity.characterNameEN = memo.characterName
+        entity.title = memo.title
+        entity.body = memo.body
+        entity.isPinned = memo.isPinned
+        entity.updatedAt = preserveUpdatedAt ? memo.updatedAt : Date()
     }
 }

--- a/Tekken8 Frame Data/TK8Tests/KRToENTranslatorTests.swift
+++ b/Tekken8 Frame Data/TK8Tests/KRToENTranslatorTests.swift
@@ -223,4 +223,23 @@ final class KRToENTranslatorTests: XCTestCase {
         let result = KRToENTranslator.translate("지상 히트 시 잡기 풀기 불가능한 특수 상태를 유발")
         XCTAssertEqual(result, "Triggers special stun state on ground hit that cannot be throw escaped")
     }
+
+    // MARK: - Judgment Translation
+
+    func test_judgment_translates_to_english_for_english_locale() {
+        XCTAssertEqual(JudgmentTranslator.localize("상", to: .en), "high")
+        XCTAssertEqual(JudgmentTranslator.localize("중", to: .en), "mid")
+        XCTAssertEqual(JudgmentTranslator.localize("하", to: .en), "low")
+    }
+
+    func test_judgment_keeps_korean_for_korean_locale() {
+        XCTAssertEqual(JudgmentTranslator.localize("상", to: .ko), "상")
+        XCTAssertEqual(JudgmentTranslator.localize("중", to: .ko), "중")
+        XCTAssertEqual(JudgmentTranslator.localize("하", to: .ko), "하")
+    }
+
+    func test_judgment_translates_compound_values_to_english() {
+        XCTAssertEqual(JudgmentTranslator.localize("상중하", to: .en), "high mid low")
+        XCTAssertEqual(JudgmentTranslator.localize("중단가불", to: .en), "mid unblockable")
+    }
 }

--- a/Tekken8 Frame Data/TK8Tests/KRToENTranslatorTests.swift
+++ b/Tekken8 Frame Data/TK8Tests/KRToENTranslatorTests.swift
@@ -242,4 +242,34 @@ final class KRToENTranslatorTests: XCTestCase {
         XCTAssertEqual(JudgmentTranslator.localize("상중하", to: .en), "high mid low")
         XCTAssertEqual(JudgmentTranslator.localize("중단가불", to: .en), "mid unblockable")
     }
+
+    func test_judgment_translates_special_values_to_english() {
+        XCTAssertEqual(JudgmentTranslator.localize("특중", to: .en), "s.mid")
+        XCTAssertEqual(JudgmentTranslator.localize("특하", to: .en), "s.low")
+        XCTAssertEqual(JudgmentTranslator.localize("가불", to: .en), "unblockable")
+        XCTAssertEqual(JudgmentTranslator.localize("상단가불", to: .en), "high unblockable")
+    }
+
+    func test_judgment_handles_nil_and_empty_values() {
+        XCTAssertNil(JudgmentTranslator.localize(nil, to: .en))
+        XCTAssertNil(JudgmentTranslator.localize(nil, to: .ko))
+        XCTAssertEqual(JudgmentTranslator.localize("", to: .en), "")
+        XCTAssertEqual(JudgmentTranslator.localize("", to: .ko), "")
+    }
+
+    func test_judgment_translates_separated_values_to_english() {
+        XCTAssertEqual(JudgmentTranslator.localize("상,중,하", to: .en), "high mid low")
+    }
+
+    func test_judgmentView_keeps_unblockable_compounds_as_single_badge() {
+        let highUnblockable = JudgmentView(judgment: JudgmentTranslator.localize("상단가불", to: .en) ?? "")
+        let midUnblockable = JudgmentView(judgment: JudgmentTranslator.localize("중단가불", to: .en) ?? "")
+
+        XCTAssertEqual(mirroredJudgments(in: highUnblockable), ["high unblockable"])
+        XCTAssertEqual(mirroredJudgments(in: midUnblockable), ["mid unblockable"])
+    }
+
+    private func mirroredJudgments(in view: JudgmentView) -> [String]? {
+        Mirror(reflecting: view).children.first { $0.label == "judgments" }?.value as? [String]
+    }
 }

--- a/Tekken8 Frame Data/TK8Tests/MemoBackupTests.swift
+++ b/Tekken8 Frame Data/TK8Tests/MemoBackupTests.swift
@@ -1,0 +1,108 @@
+//
+//  MemoBackupTests.swift
+//  TK8Tests
+//
+
+@testable import TK8
+import XCTest
+
+final class MemoBackupCodecTests: XCTestCase {
+    func test_encode_decode_roundTrip_preservesMemoFields() throws {
+        let sut = MemoBackupCodec()
+        let memo = Memo(
+            id: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            characterName: "Jin",
+            title: "Wall combo",
+            body: "Keep original memo body",
+            isPinned: true,
+            updatedAt: Date(timeIntervalSince1970: 1_725_000_000)
+        )
+
+        let data = try sut.encode(
+            memos: [memo],
+            exportedAt: Date(timeIntervalSince1970: 1_725_000_100)
+        )
+        let decoded = try sut.decodeMemos(from: data)
+
+        XCTAssertEqual(decoded, [memo])
+    }
+
+    func test_fileName_usesAppSpecificExtension() {
+        let fileName = MemoBackupDocument.fileName(exportedAt: Date(timeIntervalSince1970: 0))
+
+        XCTAssertEqual(fileName, "tekken8-memos-19700101-000000.tk8memos")
+    }
+}
+
+extension MemoRepositoryTests {
+    func test_upsert_없는_id는_새_메모로_추가함() throws {
+        let memo = Memo(
+            id: UUID(),
+            characterName: "Jin",
+            title: "백업 메모",
+            body: "복원된 메모",
+            isPinned: true,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let result = try sut.upsert(memos: [memo])
+        let fetched = try sut.fetchMemos()
+
+        XCTAssertEqual(result, MemoImportResult(insertedCount: 1, updatedCount: 0, skippedCount: 0))
+        XCTAssertEqual(fetched, [memo])
+    }
+
+    func test_upsert_같은_id가_있고_import가_더_최신이면_업데이트함() throws {
+        let id = UUID()
+        let local = Memo(
+            id: id,
+            characterName: "Jin",
+            title: "기존 메모",
+            body: "오래된 내용",
+            isPinned: false,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        let imported = Memo(
+            id: id,
+            characterName: "Jin",
+            title: "가져온 메모",
+            body: "새 내용",
+            isPinned: true,
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        _ = try sut.upsert(memos: [local])
+        let result = try sut.upsert(memos: [imported])
+        let fetched = try sut.fetchMemos()
+
+        XCTAssertEqual(result, MemoImportResult(insertedCount: 0, updatedCount: 1, skippedCount: 0))
+        XCTAssertEqual(fetched, [imported])
+    }
+
+    func test_upsert_같은_id가_있고_import가_더_오래됐으면_유지함() throws {
+        let id = UUID()
+        let local = Memo(
+            id: id,
+            characterName: "Jin",
+            title: "기존 메모",
+            body: "최신 내용",
+            isPinned: true,
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+        let imported = Memo(
+            id: id,
+            characterName: "Jin",
+            title: "가져온 메모",
+            body: "오래된 내용",
+            isPinned: false,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        _ = try sut.upsert(memos: [local])
+        let result = try sut.upsert(memos: [imported])
+        let fetched = try sut.fetchMemos()
+
+        XCTAssertEqual(result, MemoImportResult(insertedCount: 0, updatedCount: 0, skippedCount: 1))
+        XCTAssertEqual(fetched, [local])
+    }
+}

--- a/Tekken8 Frame Data/TK8Tests/MemoBackupTests.swift
+++ b/Tekken8 Frame Data/TK8Tests/MemoBackupTests.swift
@@ -32,6 +32,26 @@ final class MemoBackupCodecTests: XCTestCase {
 
         XCTAssertEqual(fileName, "tekken8-memos-19700101-000000.tk8memos")
     }
+
+    func test_decode_지원하지_않는_formatVersion이면_에러를_던짐() {
+        let sut = MemoBackupCodec()
+        let json = #"{"formatVersion":99,"exportedAt":"2024-01-01T00:00:00Z","memos":[]}"#
+
+        XCTAssertThrowsError(try sut.decodeMemos(from: Data(json.utf8))) { error in
+            guard case MemoBackupError.unsupportedFormatVersion(99) = error else {
+                XCTFail("Expected unsupportedFormatVersion error, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_decode_잘못된_JSON이면_decodingError를_던짐() {
+        let sut = MemoBackupCodec()
+
+        XCTAssertThrowsError(try sut.decodeMemos(from: Data("not json".utf8))) { error in
+            XCTAssertTrue(error is DecodingError)
+        }
+    }
 }
 
 extension MemoRepositoryTests {
@@ -50,6 +70,14 @@ extension MemoRepositoryTests {
 
         XCTAssertEqual(result, MemoImportResult(insertedCount: 1, updatedCount: 0, skippedCount: 0))
         XCTAssertEqual(fetched, [memo])
+    }
+
+    func test_upsert_빈_배열이면_모든_카운트가_0임() throws {
+        let result = try sut.upsert(memos: [])
+        let fetched = try sut.fetchMemos()
+
+        XCTAssertEqual(result, MemoImportResult(insertedCount: 0, updatedCount: 0, skippedCount: 0))
+        XCTAssertEqual(fetched, [])
     }
 
     func test_upsert_같은_id가_있고_import가_더_최신이면_업데이트함() throws {
@@ -96,6 +124,34 @@ extension MemoRepositoryTests {
             body: "오래된 내용",
             isPinned: false,
             updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        _ = try sut.upsert(memos: [local])
+        let result = try sut.upsert(memos: [imported])
+        let fetched = try sut.fetchMemos()
+
+        XCTAssertEqual(result, MemoImportResult(insertedCount: 0, updatedCount: 0, skippedCount: 1))
+        XCTAssertEqual(fetched, [local])
+    }
+
+    func test_upsert_같은_id와_updatedAt이면_기존_메모를_유지함() throws {
+        let id = UUID()
+        let updatedAt = Date(timeIntervalSince1970: 100)
+        let local = Memo(
+            id: id,
+            characterName: "Jin",
+            title: "기존 메모",
+            body: "기존 내용",
+            isPinned: false,
+            updatedAt: updatedAt
+        )
+        let imported = Memo(
+            id: id,
+            characterName: "Jin",
+            title: "가져온 메모",
+            body: "가져온 내용",
+            isPinned: true,
+            updatedAt: updatedAt
         )
 
         _ = try sut.upsert(memos: [local])

--- a/Tekken8 Frame Data/TK8Tests/MockMemoRepository.swift
+++ b/Tekken8 Frame Data/TK8Tests/MockMemoRepository.swift
@@ -29,4 +29,30 @@ final class MockMemoRepository: MemoRepository {
     func delete(memo: Memo) {
         memos.removeAll { $0.id == memo.id }
     }
+
+    func upsert(memos: [Memo]) throws -> MemoImportResult {
+        var insertedCount = 0
+        var updatedCount = 0
+        var skippedCount = 0
+
+        for memo in memos {
+            guard let index = self.memos.firstIndex(where: { $0.id == memo.id }) else {
+                self.memos.append(memo)
+                insertedCount += 1
+                continue
+            }
+            guard memo.updatedAt > self.memos[index].updatedAt else {
+                skippedCount += 1
+                continue
+            }
+            self.memos[index] = memo
+            updatedCount += 1
+        }
+
+        return MemoImportResult(
+            insertedCount: insertedCount,
+            updatedCount: updatedCount,
+            skippedCount: skippedCount
+        )
+    }
 }


### PR DESCRIPTION
##  📌 관련 이슈

- closed: #60

## ✨ 세부 내용

- 메모 전체를 `.tk8memos` 앱 전용 백업 파일로 내보내고 불러오는 기능을 추가했습니다.
- 백업 파일 내부 포맷은 JSON으로 유지하고, `id`, `characterName`, `title`, `body`, `isPinned`, `updatedAt`을 보존합니다.
- 불러오기 시 같은 `id`의 메모가 있으면 `updatedAt`이 더 최신인 쪽만 반영하는 merge/upsert 정책을 적용했습니다.
- 메모 목록 우측 ellipsis 메뉴에 `Export All Memos`, `Import Memos`를 추가했습니다.
- import 전 확인 alert를 표시하고, export/import 관련 문구의 한국어 localization을 추가했습니다.
- `.tk8memos` 문서 타입과 UTI를 등록했습니다.
- 영어 설정에서 이동 판정이 한글로 남던 문제를 함께 수정해 `high`, `mid`, `low` 등으로 표시되도록 했습니다.

## ✍️ 고민한 내용

- 단일 메모 공유보다 기기 이동/개인 백업 복구를 우선해 전체 메모 일괄 export/import를 1차 범위로 잡았습니다.
- 사용자가 직접 JSON을 편집할 가능성은 낮다고 보고, 파일 확장자는 앱 전용 `.tk8memos`로 정했습니다.
- import는 기존 데이터를 덮어쓰기보다 안전한 merge/upsert를 기본으로 두고, 같은 `id` 충돌 시 최신 `updatedAt`을 기준으로 판단하도록 했습니다.

## ✅ 검증

- `git diff --check`
- `plutil -lint 'Tekken8 Frame Data/TK8/Info.plist'`
- `ruby -rjson -e "JSON.parse(File.read('Tekken8 Frame Data/TK8/Localizable.xcstrings'))"`
- `xcodebuild test -project 'Tekken8 Frame Data/TK8.xcodeproj' -scheme 'TK8Tests' -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -derivedDataPath /private/tmp/TK8DerivedData-issue60`
- `xcodebuild test -project 'Tekken8 Frame Data/TK8.xcodeproj' -scheme 'TK8Tests' -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -derivedDataPath /private/tmp/TK8DerivedData-judgment-locale`

## ⌛ 소요 시간

- 약 2시간


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 메모를 파일로 내보내고 다시 가져오는 기능이 추가되었습니다.
  * 메모 백업 파일 형식과 문서 연동이 지원됩니다.
  * 판단(상/중/하 등) 표시가 더 정확하게 번역되고 표시됩니다.
* **Bug Fixes**
  * 가져오기 시 기존 메모와 비교해 최신 내용만 반영되도록 개선되었습니다.
  * 복합 판단 문자열과 추가 배지 값이 올바르게 인식됩니다.
* **Tests**
  * 메모 백업/복원 및 판단 번역 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->